### PR TITLE
Safety Margins for Traversability World Model

### DIFF
--- a/l3_footstep_planning_plugins/include/l3_footstep_planning_plugins/std/world_model/traversability_map_model.h
+++ b/l3_footstep_planning_plugins/include/l3_footstep_planning_plugins/std/world_model/traversability_map_model.h
@@ -133,6 +133,18 @@ protected:
   // Specifies whether the floating base of the robot should be used for the accessibility check
   bool check_floating_base_accessibility_;
 
+  // Safety margin for the robot's upper body in x direction
+  double upper_body_margin_x_;
+
+  // Safety margin for the robot's upper body in y direction
+  double upper_body_margin_y_;
+
+  // Safety margin for the robot's foothold in x direction
+  double foothold_margin_x_;
+
+  // Safety margin for the robot's foothold in y direction
+  double foothold_margin_y_;
+
   // Number of sampling points in x direction of the robot's upper body
   int num_sampling_points_x_;
 

--- a/l3_footstep_planning_plugins/include/l3_footstep_planning_plugins/std/world_model/traversability_map_model.h
+++ b/l3_footstep_planning_plugins/include/l3_footstep_planning_plugins/std/world_model/traversability_map_model.h
@@ -157,7 +157,7 @@ protected:
   // The sizes of the robot's feet
   std::vector<Vector2> feet_sizes_;
 
-  // teh shapes of the robot's feet
+  // The shapes of the robot's feet
   std::vector<FootInfo::Shape> feet_shapes_;
 };
 }  // namespace l3_footstep_planning

--- a/l3_footstep_planning_plugins/include/l3_footstep_planning_plugins/std/world_model/traversability_map_model.h
+++ b/l3_footstep_planning_plugins/include/l3_footstep_planning_plugins/std/world_model/traversability_map_model.h
@@ -153,6 +153,12 @@ protected:
 
   // The size of the robot's upper body
   Vector2 upper_body_size_;
+
+  // The sizes of the robot's feet
+  std::vector<Vector2> feet_sizes_;
+
+  // teh shapes of the robot's feet
+  std::vector<FootInfo::Shape> feet_shapes_;
 };
 }  // namespace l3_footstep_planning
 

--- a/l3_footstep_planning_plugins/src/std/world_model/traversability_map_model.cpp
+++ b/l3_footstep_planning_plugins/src/std/world_model/traversability_map_model.cpp
@@ -74,10 +74,9 @@ bool TraversabilityMapModel::loadParams(const vigir_generic_params::ParameterSet
   std::vector<FootIndex> foot_idx_list = RobotModel::description()->footIdxList();
   feet_sizes_.resize(foot_idx_list.size());
   feet_shapes_.resize(foot_idx_list.size());
-  for (FootIndex footIndex : foot_idx_list)
+  for (const FootIndex& footIndex : foot_idx_list)
   {
-    FootInfo foot_info;
-    RobotModel::description()->getFootInfo(footIndex, foot_info);
+    FootInfo foot_info = RobotModel::description()->getFootInfo(footIndex);
     size_t index = RobotModel::description()->getFootIdx(footIndex);
     feet_sizes_[index] = Vector2(foot_info.size.x() + foothold_margin_x_, foot_info.size.y() + foothold_margin_y_);
     feet_shapes_[index] = foot_info.shape;

--- a/l3_footstep_planning_plugins/src/std/world_model/traversability_map_model.cpp
+++ b/l3_footstep_planning_plugins/src/std/world_model/traversability_map_model.cpp
@@ -20,6 +20,10 @@ bool TraversabilityMapModel::loadParams(const vigir_generic_params::ParameterSet
   getParam("unknown_traversability_value", unknown_traversability_value_, 1.0f, true);
   getParam("check_foothold_accessibility", check_foothold_accessibility_, true, true);
   getParam("check_floating_base_accessibility", check_floating_base_accessibility_, true, true);
+  getParam("upper_body_margin_x", upper_body_margin_x_, 0.0, true);
+  getParam("upper_body_margin_y", upper_body_margin_y_, 0.0, true);
+  getParam("foothold_margin_x", foothold_margin_x_, 0.0, true);
+  getParam("foothold_margin_y", foothold_margin_y_, 0.0, true);
   getParam("num_sampling_points_x", num_sampling_points_x_, 5, true);
   getParam("num_sampling_points_y", num_sampling_points_y_, 10, true);
 
@@ -64,7 +68,7 @@ bool TraversabilityMapModel::loadParams(const vigir_generic_params::ParameterSet
   // get the size of the upper body
   BaseInfo base_info;
   RobotModel::description()->getBaseInfo(BaseInfo::MAIN_BODY_IDX, base_info);
-  upper_body_size_ = Vector2(base_info.size.x(), base_info.size.y());
+  upper_body_size_ = Vector2(base_info.size.x() + upper_body_margin_x_, base_info.size.y() + upper_body_margin_y_);
 
   return true;
 }
@@ -94,7 +98,7 @@ bool TraversabilityMapModel::isAccessible(const Foothold& foothold) const
 
   FootInfo foot_info;
   RobotModel::description()->getFootInfo(foothold.idx, foot_info);
-  Vector2 foot_size = Vector2(foot_info.size.x(), foot_info.size.y());
+  Vector2 foot_size = Vector2(foot_info.size.x() + foothold_margin_x_, foot_info.size.y() + foothold_margin_y_);
 
   if (foot_info.shape == FootInfo::Shape::CUBOID)
     return isPolygonAccessible(Vector2(foothold.x(), foothold.y()), foot_size, foothold.yaw());

--- a/l3_footstep_planning_plugins/src/std/world_model/traversability_map_model.cpp
+++ b/l3_footstep_planning_plugins/src/std/world_model/traversability_map_model.cpp
@@ -74,12 +74,13 @@ bool TraversabilityMapModel::loadParams(const vigir_generic_params::ParameterSet
   std::vector<FootIndex> foot_idx_list = RobotModel::description()->footIdxList();
   feet_sizes_.resize(foot_idx_list.size());
   feet_shapes_.resize(foot_idx_list.size());
-  for (size_t i = 0; i < foot_idx_list.size(); ++i)
+  for (FootIndex footIndex : foot_idx_list)
   {
     FootInfo foot_info;
-    RobotModel::description()->getFootInfo(foot_idx_list[i], foot_info);
-    feet_sizes_[i] = Vector2(foot_info.size.x() + foothold_margin_x_, foot_info.size.y() + foothold_margin_y_);
-    feet_shapes_[i] = foot_info.shape;
+    RobotModel::description()->getFootInfo(footIndex, foot_info);
+    size_t index = RobotModel::description()->getFootIdx(footIndex);
+    feet_sizes_[index] = Vector2(foot_info.size.x() + foothold_margin_x_, foot_info.size.y() + foothold_margin_y_);
+    feet_shapes_[index] = foot_info.shape;
   }
 
   return true;
@@ -108,8 +109,8 @@ bool TraversabilityMapModel::isAccessible(const Foothold& foothold) const
     return false;
   }
 
-  Vector2 foot_size = feet_sizes_[foothold.idx];
-  FootInfo::Shape foot_shape = feet_shapes_[foothold.idx];
+  Vector2 foot_size = feet_sizes_[RobotModel::description()->getFootIdx(foothold.idx)];
+  FootInfo::Shape foot_shape = feet_shapes_[RobotModel::description()->getFootIdx(foothold.idx)];
 
   if (foot_shape == FootInfo::Shape::CUBOID)
     return isPolygonAccessible(Vector2(foothold.x(), foothold.y()), foot_size, foothold.yaw());


### PR DESCRIPTION
This feature makes it possible to increase the footprint of the robot during the accessibility check. This leads to only "safer" states being considered.